### PR TITLE
settings for aspire dashbord

### DIFF
--- a/API/Program.cs
+++ b/API/Program.cs
@@ -29,7 +29,7 @@ public class Program
 		builder.Services.AddScoped<IBookingInterface, BookingService>();
         builder.Services.AddScoped<ILoginAttemptService, LoginAttemptService>();
         builder.Services.AddMemoryCache();
-
+        builder.AddServiceDefaults();
         // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
         builder.Services.AddSwaggerGen(c =>
 		{
@@ -89,11 +89,10 @@ public class Program
 			);
 		});
 
-		// Tilføj basic health checks
-		builder.Services.AddHealthChecks()
-			.AddCheck("self", () => Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult.Healthy(), ["live"]);
+        // Tilføj basic health checks
+        builder.Services.AddHealthChecks();
 
-		IConfiguration Configuration = builder.Configuration;
+        IConfiguration Configuration = builder.Configuration;
 		string connectionString = Configuration.GetConnectionString("DefaultConnection")
 			?? Environment.GetEnvironmentVariable("DefaultConnection");
 
@@ -156,7 +155,8 @@ public class Program
 		app.UseAuthentication();
 		app.UseAuthorization();
 
-		app.MapControllers();
+        app.MapDefaultEndpoints();
+        app.MapControllers();
 
 		app.Run();
 	}


### PR DESCRIPTION
Running the Project with Aspire
The project now uses Aspire orchestration.
You don’t need to run the API and Blazor separately anymore — simply start H2-Projekt.AppHost.
H2-Projekt.AppHost — the main host that orchestrates all services (API, Blazor, database, and other dependencies).

After startup, the Aspire Dashboard will open in your browser.

From the Dashboard you can:
view structured logs,
see the ports where API and Blazor apps are running,
manage dependencies (SQL, Redis, MessageBus, etc.).

To run the whole solution:

In Visual Studio / VS Code  set H2-Projekt.AppHost as the startup project.

Press Run.

Aspire will automatically start the API and Blazor apps with the correct configuration and display them in the Dashboard.