### PR TITLE
106 fix user state

### DIFF
--- a/API/Services/AuthService.cs
+++ b/API/Services/AuthService.cs
@@ -125,9 +125,9 @@ public class AuthService : IAuthService
 			new Claim(ClaimTypes.Role, user.UserRole.RoleName.ToString())
 		};
 
-
+		string secretKey = _configuration["AppSettings:Token"]!;
 		var key = new SymmetricSecurityKey(
-			Encoding.UTF8.GetBytes(_configuration.GetValue<string>("AppSettings:Token")!));
+			Encoding.UTF8.GetBytes(secretKey));
 
 		var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha512);
 		var tokenDescriptor = new SecurityTokenDescriptor
@@ -135,7 +135,7 @@ public class AuthService : IAuthService
 			Subject = new ClaimsIdentity(claims),
 			Issuer = _configuration.GetValue<string>("AppSettings:Issuer"),
 			Audience = _configuration.GetValue<string>("AppSettings:Audience"),
-			Expires = DateTime.UtcNow.AddHours(3), // 2 hours + 60 minutes = 3 hours
+			Expires = DateTime.UtcNow.AddHours(1), 
 			SigningCredentials = creds
 		};
 

--- a/Blazor/CustomAuthStateProvider.cs
+++ b/Blazor/CustomAuthStateProvider.cs
@@ -25,8 +25,8 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
 	public override async Task<AuthenticationState> GetAuthenticationStateAsync()
 	{
 		//Check if token exists in local storage
-		var savedToken = await _localStorage.GetItemAsStringAsync(_tokenKey) 
-			?? await _sessionStorage.GetItemAsStringAsync(_tokenKey);
+		var savedToken = await _sessionStorage.GetItemAsStringAsync(_tokenKey)
+			?? await _localStorage.GetItemAsStringAsync(_tokenKey);
 
 		//If no token, return anonymous user
 		if (string.IsNullOrWhiteSpace(savedToken))
@@ -53,12 +53,15 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
 		var identity = new ClaimsIdentity(claims, "jwt");
 		var user = new ClaimsPrincipal(identity);
 
-		NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(user)));
+		var authState = Task.FromResult(new AuthenticationState(user));
+
+		NotifyAuthenticationStateChanged(authState);
 	}
 
 	public void NotifyUserLogout()
 	{
-		var authState = Task.FromResult(new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity())));
+		var anonymousUser = new ClaimsPrincipal(new ClaimsIdentity());
+		var authState = Task.FromResult(new AuthenticationState(anonymousUser));
 		NotifyAuthenticationStateChanged(authState);
 	}
 

--- a/Blazor/CustomAuthStateProvider.cs
+++ b/Blazor/CustomAuthStateProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using Blazor.Services;
 using Blazored.LocalStorage;
 using Blazored.SessionStorage;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -12,19 +13,20 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
 	private readonly ILocalStorageService _localStorage;
 	private readonly ISessionStorageService _sessionStorage;
 	private readonly JwtSecurityTokenHandler _tokenHandler = new();
-	private readonly HttpClient _httpClient;
+	private readonly APIService _apiService;
 	private const string _tokenKey = "authToken";
 
-	public CustomAuthStateProvider(ILocalStorageService localStorage, ISessionStorageService sessionStorage,  HttpClient httpClient)
+	public CustomAuthStateProvider(ILocalStorageService localStorage, ISessionStorageService sessionStorage,  APIService apiService)
 	{
 		_localStorage = localStorage;
 		_sessionStorage = sessionStorage;
-		_httpClient = httpClient;
+		_apiService = apiService;
 	}
 
+	// Returns the current authentication state
 	public override async Task<AuthenticationState> GetAuthenticationStateAsync()
 	{
-		//Check if token exists in local storage
+		// Try to get the token from session storage first, then local storage
 		var savedToken = await _sessionStorage.GetItemAsStringAsync(_tokenKey)
 			?? await _localStorage.GetItemAsStringAsync(_tokenKey);
 
@@ -34,34 +36,45 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
 			return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
 		}
 
+		// Remove any surrounding quotes from the token
+		var cleanToken = savedToken.Trim('"');
+
 		//Set the token in the HttpClient for future requests, so that it is available after a page refresh
-		_httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", savedToken);
+		_apiService.SetBearerToken(cleanToken);
 
 		//If token exists, parse claims and create authenticated user
-		var claims = ParseClaimsFromJwt(savedToken);
+		var claims = ParseClaimsFromJwt(cleanToken);
 
+		// Create a ClaimsIdentity with the parsed claims and authentication type "jwt"
 		var identity = new ClaimsIdentity(claims, "jwt");
+		// Create a ClaimsPrincipal (the user) from the identity
 		var user = new ClaimsPrincipal(identity);
 
 		//Notify the application about the authentication state change
 		return new AuthenticationState(user);
 	}
 
+	// Notifies the app that the user has authenticated with a given token
 	public void NotifyUserAuthentication (string token)
 	{
-		var claims = ParseClaimsFromJwt(token);
+		var claims = ParseClaimsFromJwt(token.Trim('"'));
 		var identity = new ClaimsIdentity(claims, "jwt");
 		var user = new ClaimsPrincipal(identity);
 
+		// Create an AuthenticationState for the authenticated user
 		var authState = Task.FromResult(new AuthenticationState(user));
 
+		// Notify Blazor that the authentication state has changed
 		NotifyAuthenticationStateChanged(authState);
 	}
 
 	public void NotifyUserLogout()
 	{
+		// Create an anonymous ClaimsPrincipal (no identity)
 		var anonymousUser = new ClaimsPrincipal(new ClaimsIdentity());
+		// Create an AuthenticationState for the anonymous user
 		var authState = Task.FromResult(new AuthenticationState(anonymousUser));
+		// Notify Blazor that the authentication state has changed
 		NotifyAuthenticationStateChanged(authState);
 	}
 

--- a/Blazor/Pages/Test.razor
+++ b/Blazor/Pages/Test.razor
@@ -1,0 +1,16 @@
+﻿@page "/test"
+
+
+<h3 class="mt-5">Testing re-routing to see how works authentica.</h3>
+<AuthorizeView>
+	<Authorized>
+		<h3>You are authorized!</h3>
+	</Authorized>
+	<NotAuthorized>
+		<h3>You are not authorized. Please log in.</h3>
+	</NotAuthorized>
+</AuthorizeView>
+
+@code {
+
+}

--- a/Blazor/Services/AuthService.cs
+++ b/Blazor/Services/AuthService.cs
@@ -43,7 +43,7 @@ public class AuthService : IAuthService
 		// Read the token from the response
 		var token = await response.Content.ReadAsStringAsync();
 		var cleanToken = token.Trim('"');
-		Console.WriteLine(cleanToken);
+
 		// Store the token in local storage if remember me is checked, otherwise in session storage
 		if (remember)
 		{

--- a/Blazor/_Imports.razor
+++ b/Blazor/_Imports.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.AspNetCore.Components.Authorization;
+@using Microsoft.AspNetCore.Authorization;
 @using Microsoft.JSInterop
 @using Blazored.LocalStorage;
 @using Blazor


### PR DESCRIPTION
Now the user stays authenticated across the refreshes. The most significant changes include refactoring token management to consistently use the `authToken` key, improving how tokens are stored and cleaned, and updating the authentication state provider to use `APIService` for setting bearer tokens. Additionally, a new test page for authorization was added. It can be used for testing and debugging of some functionalities for Authorized and Unauthorized users. Should not be added to navigation